### PR TITLE
bugfix: node/npmのバージョンによりnpm installがコケる問題の解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [16.15.0]
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [16]
+        node: [16.15.0]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 問題

CI設定( `./github/workflwos/ci.yml` ) では、

`node-version: 16`

という風に「メジャーバージョンの大まかな指定」により、node/npmのVersion指定を行っていた。

この指定では、Github Actions の `actions/setup-node@v3` により「そのメジャーバージョンのlatest」が自動的に使用される。

---

上記の指定では「新しいマイナーバージョン」が出た場合、CIで自動的にバージョンアップされる場合がある。

その影響で、

- node.js: 16.15.1
- npm: 8.11.0

のバージョンへといつの間にか上がったらしく、 `npm install` が失敗するようになっていた。

##  対応

Github Actions の `actions/setup-node@v3` に、マイナーバージョンまで詳細に `16.15.0` と指定することにより、

- node.js: 16.15.0
- npm: 8.5.5

の組み合わせとなり、この場合は `npm install` が失敗しないため、一律その設定に。

## 補足

`npm install` の結果が

- node.js:16.13.0, npm:8.1.0 -> 成功 <- ローカル実行環境
- node.js:16.14.2, npm:8.5.0 -> 成功 
- node.js:16.15.0, npm:8.5.5 -> 成功 
- node.js:16.15.1, npm:8.11.0 -> 失敗
- node.js:17.0.1, npm:8.1.0 -> 成功

と鳴っていることから、おそらく

1. npmのバージョンによってはinstallが不可能になる
0. 新しすぎるものはNG

なのではないか？と推測する。