### PR TITLE
Node.js/npm のVerUP(失敗)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ RDRAM
 
 <https://kazuhito-m.github.io/rdram> (暫定、近々変わります)
 
+## Prerequisite
+
+開発に使う `Node.js` のバージョンは、 CIのファイルである `.circleci/config.yml`, `.github/workflows/deploy.yml` を参照。
+
 ## author
 
 Kazuhito Miura ( [@kazuhito_m](https://twitter.com/kazuhito_m "kazuhito_m on Twitter") )

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 RDRAM
-==========================
+=====
 
 [![ci](https://github.com/kazuhito-m/rdram/actions/workflows/ci.yml/badge.svg)](https://github.com/kazuhito-m/rdram/actions/workflows/ci.yml) [![gh-pages-deploy](https://github.com/kazuhito-m/rdram/actions/workflows/deploy.yml/badge.svg)](https://github.com/kazuhito-m/rdram/actions/workflows/deploy.yml)
 
@@ -17,6 +17,6 @@ RDRAM
 
 開発に使う `Node.js` のバージョンは、 CIのファイルである `.circleci/config.yml`, `.github/workflows/deploy.yml` を参照。
 
-## author
+## Author
 
 Kazuhito Miura ( [@kazuhito_m](https://twitter.com/kazuhito_m "kazuhito_m on Twitter") )


### PR DESCRIPTION
本当は掲題のようにしたかったのだが…。

- node : v16.15.0
- npm : 8.5.5

から「ビタ1Verでも動かせば、`npm install` すらできなくなる」という、奇跡のバランスで出来ているので、動かせ無かった。

READMEを更新した。